### PR TITLE
Add subaccount feature and ability to white/blacklist customer

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ var resources = {
   plan: require('./resources/plan'),
   transaction: require('./resources/transaction'),
   page: require('./resources/page'),
-  subscription: require('./resources/subscription')
+  subscription: require('./resources/subscription'),
+  subaccount: require('./resources/subaccount')
 }
 
 function Paystack(key) {

--- a/resources/customer.js
+++ b/resources/customer.js
@@ -40,5 +40,15 @@ module.exports = {
       endpoint: [root, '/{id}'].join(''),
       params: ['first_name', 'last_name', 'email', 'phone'],
       args: ['id']
-    }
+    },
+
+  /*
+  White/Blacklist customer
+  @param: customer, risk_action ('allow' to whitelist or 'deny' to blacklist)
+  */
+  setRiskAction: {
+    method: 'post',
+    endpoint: [root, '/set_risk_action'].join(''),
+    params: ['customer', 'risk_action']
+  }
 };

--- a/resources/subaccount.js
+++ b/resources/subaccount.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var root = '/subaccount';
+
+module.exports = {
+
+  /*
+  Create subaccount
+  @param: business_name, settlement_bank, account_number, percentage_charge
+  */
+  create: {
+      method: 'post',
+      endpoint: root,
+      params: ['business_name', 'settlement_bank', 'account_number', 'percentage_charge']
+    },
+
+  /*
+  Get subaccount
+  */
+  get: {
+      method: 'get',
+      endpoint: [root, '/{id_or_slug}'].join(''),
+      args: ['id_or_slug']
+    },
+
+  /*
+  List subaccount
+  */
+  list: {
+      method: 'get',
+      endpoint: root
+    },
+
+  /*
+  List supported banks
+  */
+  listBanks: {
+      method: 'get',
+      endpoint: '/bank'
+    },
+
+  /*
+  Update subaccount
+  @param: business_name, settlement_bank, account_number, percentage_charge
+  */
+  update: {
+      method: 'put',
+      endpoint: [root, '/{id_or_slug}'].join(''),
+      params: ['business_name', 'settlement_bank', 'account_number', 'percentage_charge'],
+      args: ['id_or_slug']
+    }
+};

--- a/test/customer.js
+++ b/test/customer.js
@@ -68,5 +68,26 @@ describe("Paystack Customers", function() {
       done();
     });
   });
+
+  //Whitelist Customer
+  /*
+  setRiskAction integration not available
+  on test integration
+  it("should whitelist customer", function(done) {
+    paystack.customer.setRiskAction({
+      "customer": customer_id,
+      "risk_action": "allow"
+    }, function(error, body) {
+
+      if (error)
+        return done(error);
+
+      expect(body).to.have.property('data');
+      expect(body.data).to.have.property('risk_action');
+
+      done();
+    });
+  });
+  */
 });
 

--- a/test/subaccount.js
+++ b/test/subaccount.js
@@ -1,0 +1,94 @@
+var paystack = require('../index')(process.env.KEY)
+  , mocha = require('mocha')
+  , expect = require('chai').expect
+  ;
+
+
+describe("Paystack Subaccount", function() {
+
+  var subaccount_id, subaccount_code;
+
+  // New Subaccount
+  it("should create a new subaccount", function(done) {
+    paystack.subaccount.create({
+      business_name: 'Super Cool Inc',
+      settlement_bank: 'Access Bank',
+      account_number: '0193274682',
+      percentage_charge: 18.2
+    }, function(error, body) {
+
+      if (error)
+        return done(error);
+
+      expect(body).to.have.property('data');
+      expect(body.data).to.have.property('id');
+      expect(body.data).to.have.property('subaccount_code');
+
+      subaccount_id = body.data.id;
+      subaccount_code = body.data.subaccount_code;
+
+      done();
+    });
+  });
+
+  // Update Subaccount
+  it("should update a subaccount", function(done) {
+    paystack.subaccount.update(subaccount_code, {
+      primary_contact_email: 'wale@obo.com',
+      percentage_charge: 98.9
+    }, function(error, body) {
+
+      if (error)
+        return done(error);
+
+      expect(body).to.have.property('data');
+      expect(body.data).to.have.property('id');
+
+      done();
+    });
+  });
+
+  // Fetch Subaccount
+  it("should get details of a subaccount", function(done) {
+    paystack.subaccount.get(subaccount_code, function(error, body) {
+
+      if (error)
+        return done(error);
+
+      expect(body).to.have.property('data');
+      expect(body.data).to.have.property('id');
+
+      done();
+    });
+  });
+
+  // list Banks
+  it("should list supported banks", function(done) {
+    paystack.subaccount.listBanks(function(error, body) {
+
+      if (error)
+        return done(error);
+
+      expect(body).to.have.property('data');
+      expect(body.data).to.be.instanceof(Array);
+
+      done();
+    });
+  });
+
+
+  // List Subaccounts
+  it("should list subaccounts", function(done) {
+    paystack.subaccount.list(function(error, body) {
+
+      if (error)
+        return done(error);
+
+      expect(body).to.have.property('data');
+      expect(body.data).to.be.instanceof(Array);
+
+      done();
+    });
+  });
+
+});


### PR DESCRIPTION
Implemented the new [Paystack subaccount feature](https://developers.paystack.co/docs/create-subaccount) and white/blacklist customer to the Customer API with all tests passing 

[Split Payments Overview](https://developers.paystack.co/docs/split-payments-overview)