### PR TITLE
Updated paystack api for enable/disable subscriptions

### DIFF
--- a/resources/subscription.js
+++ b/resources/subscription.js
@@ -18,7 +18,7 @@ module.exports = {
   */
   disable: {
       method: 'post',
-      endpoint: root,
+      endpoint: root+"/disable",
       params: ['code*', 'token*']
     },
 
@@ -27,7 +27,7 @@ module.exports = {
   */
   enable: {
       method: 'post',
-      endpoint: root,
+      endpoint: root+"/enable",
       params: ['code*', 'token*']
     },
 


### PR DESCRIPTION
## Current Behaviour
* Calling `disable/enable` function on subscription times out because the api end-points are out-dated

## New Behaviour
* Api end-points to `disable/enable` subscriptions has been updated and now returns the appropriate response